### PR TITLE
feat: add home navigation to pages missing it

### DIFF
--- a/app/(authority)/authority/login/page.tsx
+++ b/app/(authority)/authority/login/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { LoginForm } from '@/components/authority/login-form'
 
 export const metadata: Metadata = {
@@ -29,6 +30,11 @@ export default function AuthorityLoginPage() {
           </p>
         </div>
         <LoginForm />
+        <p style={{ textAlign: 'center', marginTop: 24 }}>
+          <Link href="/" style={{ color: 'var(--text-muted)', fontSize: 13, fontFamily: 'var(--font-barlow-condensed)', textDecoration: 'none', letterSpacing: 1 }}>
+            ← Public site
+          </Link>
+        </p>
       </div>
     </main>
   )

--- a/app/(citizen)/complaints/[ticket]/page.tsx
+++ b/app/(citizen)/complaints/[ticket]/page.tsx
@@ -1,8 +1,20 @@
+import Link from 'next/link'
+
 export default async function ComplaintPage({
   params: paramsPromise,
 }: {
   params: Promise<{ ticket: string }>
 }) {
   const params = await paramsPromise
-  return <main className="min-h-screen p-4">Complaint {params.ticket} — TODO</main>
+  return (
+    <main className="min-h-screen p-4" style={{ background: 'var(--surface-base)', color: 'var(--text-primary)' }}>
+      <Link
+        href="/"
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-muted)', fontSize: 13, fontFamily: 'var(--font-barlow-condensed)', textDecoration: 'none', letterSpacing: 1, marginBottom: 24 }}
+      >
+        ← HOME
+      </Link>
+      <p style={{ color: 'var(--text-muted)' }}>Complaint {params.ticket} — TODO</p>
+    </main>
+  )
 }

--- a/app/(public)/transparency/page.tsx
+++ b/app/(public)/transparency/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { createServiceSupabaseClient } from '@/lib/supabase/server'
 
 export const metadata: Metadata = {
@@ -37,6 +38,14 @@ export default async function TransparencyPage() {
 
   return (
     <main style={{ minHeight: '100vh', background: 'var(--surface-base)', color: 'var(--text-primary)', maxWidth: 900, margin: '0 auto', padding: 32 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 32 }}>
+        <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-muted)', fontSize: 13, fontFamily: 'var(--font-barlow-condensed)', textDecoration: 'none', letterSpacing: 1, transition: 'color 0.15s' }}>
+          ← HOME
+        </Link>
+        <Link href="/report" style={{ display: 'inline-flex', alignItems: 'center', gap: 6, background: 'var(--brand-primary)', color: '#0A0A0A', fontSize: 13, fontFamily: 'var(--font-barlow-condensed)', fontWeight: 700, textDecoration: 'none', letterSpacing: 1, padding: '6px 14px', borderRadius: 4 }}>
+          + REPORT INCIDENT
+        </Link>
+      </div>
       <h1 style={{ fontFamily: 'var(--font-barlow-condensed)', fontSize: 40, margin: '0 0 8px' }}>TRANSPARENCY DASHBOARD</h1>
       <p style={{ color: 'var(--text-muted)', marginBottom: 40 }}>Public accountability for civic response in Jamaica</p>
 

--- a/components/authority/sidebar-nav.tsx
+++ b/components/authority/sidebar-nav.tsx
@@ -90,6 +90,13 @@ export function SidebarNav({ orgName, userName, unreadCount = 0, orgId }: Sideba
 
       {/* User + sign out */}
       <div style={{ padding: 16, borderTop: '1px solid var(--border)' }}>
+        <Link
+          href="/"
+          style={{ display: 'flex', alignItems: 'center', gap: 8, color: 'var(--text-muted)', fontSize: 13, fontFamily: 'var(--font-barlow)', textDecoration: 'none', marginBottom: 12, padding: '4px 0' }}
+        >
+          <span>🏠</span>
+          <span>Public site</span>
+        </Link>
         <p style={{ color: 'var(--text-muted)', fontSize: 12, margin: '0 0 8px' }}>{userName}</p>
         <button onClick={handleSignOut}
           style={{ width: '100%', padding: '8px', background: 'none', border: '1px solid var(--border)', borderRadius: 6, color: 'var(--text-secondary)', cursor: 'pointer', fontSize: 13, fontFamily: 'var(--font-barlow)' }}>


### PR DESCRIPTION
## Changes

Adds a home navigation link to every route that had no path back to the home page (`/`).

### Pages updated

| Page | Change |
|---|---|
| `/transparency` | `← HOME` link (top-left) + `+ REPORT INCIDENT` CTA (top-right) |
| `/complaints/[ticket]` | `← HOME` link above stub content |
| `/authority/login` | `← Public site` link below login form |
| Authority sidebar (`queue`, `analytics`, `authority/map`) | `🏠 Public site` link in sidebar footer — one change covers all three pages |

### Not changed
- `/report` — the existing `←` back button already navigates to `/` on the first step
- `/leaderboard`, `/report/[id]`, `/incidents/[id]`, `/(citizen)/map` — already have home links

Co-Authored-By: Oz <oz-agent@warp.dev>